### PR TITLE
fix(edac-util): Correct name

### DIFF
--- a/cmd/edac-util/main.go
+++ b/cmd/edac-util/main.go
@@ -18,5 +18,12 @@ func main() {
 			log.Fatal(err)
 		}
 		fmt.Printf("%#v\n", i)
+		ranks, err := c.DimmRanks()
+		if err != nil {
+			log.Fatal(err)
+		}
+		for _, r := range ranks {
+			fmt.Printf("%#v\n", r)
+		}
 	}
 }


### PR DESCRIPTION
Correct typo in edac-util name.

Also:
* Add output of dimm / rank information.

Fixes #3